### PR TITLE
Deep equal check in the Update method of the Property struct

### DIFF
--- a/property.go
+++ b/property.go
@@ -1,6 +1,9 @@
 package observer
 
-import "sync"
+import (
+	"reflect"
+	"sync"
+)
 
 // Property is an object that is continuously updated by one or more
 // publishers. It is completely goroutine safe: you can use Property
@@ -36,6 +39,9 @@ func (p *property) Value() interface{} {
 func (p *property) Update(value interface{}) {
 	p.Lock()
 	defer p.Unlock()
+	if reflect.DeepEqual(p.state.value, value) {
+		return
+	}
 	p.state = p.state.update(value)
 }
 


### PR DESCRIPTION
In the current implementation, the Update method on the Property struct would notify all observer irrespective of whether a value actually changed or not. With a deep equal comparison we can ensure that the state is only updated when there is an actual change in the value. 