### PR TITLE
Peek() into next state without advancing stream

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -30,6 +30,10 @@ type Stream interface {
 	// they may have different values depending on when they advance the stream
 	// with Next.
 	Clone() Stream
+
+	// Peek return the value in the next state
+	// You should never call this unless Changes channel is closed.
+	Peek() interface{}
 }
 
 type stream struct {
@@ -66,4 +70,8 @@ func (s *stream) WaitNext() interface{} {
 	<-s.state.done
 	s.state = s.state.next
 	return s.state.value
+}
+
+func (s *stream) Peek() interface{} {
+	return s.state.next.value
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -137,6 +137,23 @@ func TestStreamClone(t *testing.T) {
 	}
 }
 
+func TestStreamPeek(t *testing.T) {
+	state := newState(10)
+	stream := &stream{state: state}
+	state = state.update(15)
+	if val := stream.Peek(); val != 15 {
+		t.Fatalf("Expecting 15 but got %#v\n", val)
+	}
+	state = state.update(20)
+	if val := stream.Peek(); val != 15 {
+		t.Fatalf("Expecting 15 but got %#v\n", val)
+	}
+	stream.Next()
+	if val := stream.Peek(); val != 20 {
+		t.Fatalf("Expecting 20 but got %#v\n", val)
+	}
+}
+
 func TestStreamConcurrencyWithClones(t *testing.T) {
 	initial := 1000
 	final := 2000


### PR DESCRIPTION
In some use case it would be nice to look at the next value without advancing the stream. We have the case where we send logs to the cloud but if the sending fails we need to retry. Peek could help to only advance the stream if the sending succeed otherwise we would sleep and retry.

It could look something like this
```
RETRY:
for {
  select {
    <-stream.Changes()
    val := stream.Peek()
    err := send(val); err != nil {
      // retry sending the same value
      sleep.Time(1*time.Minute)
      continue RETRY
    }
    // send succeeded (advance the stream)
    stream.Next()
  }
}
```