### PR TITLE
Add WaitNextCtx() for convenient context usage

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -80,13 +80,16 @@ func (s *stream[T]) WaitNext() T {
 func (s *stream[T]) WaitNextCtx(ctx context.Context) (T, error) {
 	select {
 	case <-s.Changes():
-		// always return context.Err() to indicate a cancelled or timed out context
-		return s.Next(), ctx.Err()
+		// ensure that context is not canceled, only then advance the stream
+		if ctx.Err() == nil {
+			return s.Next(), nil
+		}
 
 	case <-ctx.Done():
-		var zeroVal T
-		return zeroVal, ctx.Err()
 	}
+
+	var zeroVal T
+	return zeroVal, ctx.Err()
 }
 
 func (s *stream[T]) Peek() T {

--- a/stream.go
+++ b/stream.go
@@ -27,9 +27,7 @@ type Stream[T any] interface {
 	// the current value.
 	WaitNext() T
 
-	// WaitNextCtx waits for Changes to be closed or the passed context to be canceled.
-	// When Changes is closed first, it advances the stream and returns the current value.
-	// When the context is canceled first, the error recieved from the context is returned.
+	// WaitNextCtx does the same as WaitNext but returns earlier with an error if the given context is cancelled first.
 	WaitNextCtx(ctx context.Context) (T, error)
 
 	// Clone creates a new independent stream from this one but sharing the same

--- a/stream.go
+++ b/stream.go
@@ -79,10 +79,9 @@ func (s *stream[T]) WaitNext() T {
 
 func (s *stream[T]) WaitNextCtx(ctx context.Context) (T, error) {
 	select {
-	// wait for changes
 	case <-s.Changes():
-		// advance to next value and return it
-		return s.Next(), nil
+		// always return context.Err() to indicate a cancelled or timed out context
+		return s.Next(), ctx.Err()
 
 	case <-ctx.Done():
 		var zeroVal T

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,7 +2,6 @@ package observer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -153,8 +152,8 @@ func TestStreamWaitsNextCtxCancelledEarly(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		// ensure the method returns the error for a cancelled context
 		_, err := stream.WaitNextCtx(ctx)
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("Expecting error to be context.Canceled\n")
+		if err == nil {
+			t.Fatalf("Expecting error but got none\n")
 		}
 	}
 }
@@ -167,8 +166,8 @@ func TestStreamWaitsNextCtxTimedOut(t *testing.T) {
 	stream := &stream[int]{state: state}
 	state = state.update(17)
 	_, err := stream.WaitNextCtx(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Expecting error to be context.DeadlineExceeded\n")
+	if err == nil {
+		t.Fatalf("Expecting error but got none\n")
 	}
 }
 


### PR DESCRIPTION
Having a WaitNext() method/implementation that also supports the usage of a given context often comes in handy, e.g.:

```
ctx, cancel := context.WithCancel(context.Background())

prop := NewProperty(0)
stream := prop.Observe()

go func() {
	for {
		got, err := stream.WaitNextCtx(ctx)
		if err != nil {
			// context canceled
			fmt.Println("I got cancled")
			return
		}

		fmt.Println("got value", got)
	}
}()

for i := 1337; i < 2000; i++ {
	prop.Update(i)
}

time.Sleep(1 * time.Second)

cancel()

time.Sleep(1 * time.Second)
```